### PR TITLE
Fix: Pass options prop to editor instance.

### DIFF
--- a/apps/vue-image-editor/src/ImageEditor.vue
+++ b/apps/vue-image-editor/src/ImageEditor.vue
@@ -28,7 +28,7 @@ export default {
     },
   },
   mounted() {
-    let options = editorDefaultOptions;
+    let options = this.options;
     if (this.includeUi) {
       options = Object.assign(includeUIOptions, this.options);
     }


### PR DESCRIPTION
fix: Pass options prop to editor instance.

### Description
This PR fixes an issue with vue wrapper component not setting editor options properly.